### PR TITLE
feat: add enum validator for DTOs

### DIFF
--- a/src/main/java/com/riwi/riwi_projects_system/common/infrastructure/validators/enums/EnumValidator.java
+++ b/src/main/java/com/riwi/riwi_projects_system/common/infrastructure/validators/enums/EnumValidator.java
@@ -1,0 +1,22 @@
+package com.riwi.riwi_projects_system.common.infrastructure.validators.enums;
+
+import java.util.Arrays;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class EnumValidator implements ConstraintValidator<ValidEnum, String> {
+  private Class<? extends Enum<?>> enumClass;
+
+  @Override
+  public void initialize(ValidEnum constraintAnnotation) {
+    this.enumClass = constraintAnnotation.enumClass();
+  }
+
+  @Override
+  public boolean isValid(String value, ConstraintValidatorContext context) {
+    if (value == null)
+      return false;
+    return Arrays.stream(this.enumClass.getEnumConstants()).map(Enum::name).anyMatch(value::equals);
+  }
+}

--- a/src/main/java/com/riwi/riwi_projects_system/common/infrastructure/validators/enums/ValidEnum.java
+++ b/src/main/java/com/riwi/riwi_projects_system/common/infrastructure/validators/enums/ValidEnum.java
@@ -1,0 +1,25 @@
+package com.riwi.riwi_projects_system.common.infrastructure.validators.enums;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+@Documented
+@Constraint(validatedBy = EnumValidator.class)
+@Target({ ElementType.FIELD })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ValidEnum {
+
+  String message() default "Invalid value for enum";
+
+  Class<?>[] groups() default {};
+
+  Class<? extends Payload>[] payload() default {};
+
+  Class<? extends Enum<?>> enumClass();
+}


### PR DESCRIPTION
# Usage example
```java
public class Test {
  @Schema(example = "STUDENT", description = "Role of the user")
  @NotBlank(message = "Role cannot be blank")
  @ValidEnum(enumClass = Roles.class, message = "Role must be either 'STUDENT', 'TEACHER' or 'ADMIN")
  private String role;
}
```